### PR TITLE
fix: Remove concurrent update of circleci workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ workflows:
               only: /.*/
       - test:
           requires:
-            - checkout
+            - build
           filters:
             tags:
               only: /.*/
@@ -134,7 +134,7 @@ workflows:
               only: /.*/
       - lint:
           requires:
-            - checkout
+            - build
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
This avoids concurrency error when test and build update workspace